### PR TITLE
feat: fix bug to change getUserInfo() API's method from POST to GET

### DIFF
--- a/lib/src/casdoor.dart
+++ b/lib/src/casdoor.dart
@@ -171,7 +171,7 @@ class Casdoor {
   }
 
   Future<http.Response> getUserInfo(String accessToken) async {
-    return await http.post(
+    return await http.get(
       Uri(
         scheme: parseScheme(),
         host: parseHost(),


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-flutter-sdk/issues/45

This PR fixes the `getUserInfo` method to use GET instead of POST, aligning with the [[Swagger API documentation](https://demo.casdoor.com/swagger/#/Account%20API/ApiController.UserInfo)](https://demo.casdoor.com/swagger/#/Account%20API/ApiController.UserInfo). This resolves the "Unauthorized operation" error described in issue #45.