### PR TITLE
feat: fix null bug for clientSecret in refreshToken

### DIFF
--- a/lib/src/casdoor.dart
+++ b/lib/src/casdoor.dart
@@ -130,6 +130,15 @@ class Casdoor {
 
   Future<http.Response> refreshToken(String refreshToken, String? clientSecret,
       {String scope = 'read'}) async {
+    final body = {
+      'grant_type': 'refresh_token',
+      'refresh_token': refreshToken,
+      'scope': scope,
+      'client_id': config.clientId,
+    };
+    if (clientSecret != null) {
+      body['client_secret'] = clientSecret;
+    }
     return await http.post(
         Uri(
           scheme: parseScheme(),
@@ -137,13 +146,7 @@ class Casdoor {
           port: parsePort(),
           path: 'api/login/oauth/refresh_token',
         ),
-        body: {
-          'grant_type': 'refresh_token',
-          'refresh_token': refreshToken,
-          'scope': scope,
-          'client_id': config.clientId,
-          'client_secret': clientSecret
-        });
+        body: body);
   }
 
   Future<http.Response> tokenLogout(


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-flutter-sdk/issues/47

This PR addresses issue #47, where the `refreshToken` function fails when `clientSecret` is `null`. The root cause was the inclusion of a `null` value for `client_secret` in the request body, leading to a type casting error. The `casdoor.refreshToken` function has been updated to exclude the `client_secret` field when it is `null`. This ensures proper handling of such cases and prevents runtime errors. 