### PR TITLE
feat: clear cache on logout

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: "3.22.3"
+          flutter-version: "3.24.5"
       - name: Install dependencies
         run: flutter packages get
       - name: Analyze

--- a/lib/src/casdoor_flutter_sdk_config.dart
+++ b/lib/src/casdoor_flutter_sdk_config.dart
@@ -14,6 +14,9 @@
 
 import 'package:flutter/widgets.dart';
 
+const CASDOOR_USER_AGENT =
+    'Mozilla/5.0 (Android 14; Mobile; rv:123.0) Gecko/123.0 Firefox/123.0';
+
 class AuthConfig {
   final String clientId;
   final String serverUrl;
@@ -37,19 +40,17 @@ class CasdoorSdkParams {
     required this.url,
     required this.callbackUrlScheme,
     this.buildContext,
-    this.showFullscreen,
-    this.isMaterialStyle,
-    this.preferEphemeral,
-    this.clearCache,
+    this.showFullscreen = false,
+    this.isMaterialStyle = true,
+    this.clearCache = false,
   });
 
   final String url;
   final String callbackUrlScheme;
   BuildContext? buildContext;
-  bool? showFullscreen;
-  bool? isMaterialStyle;
-  bool? preferEphemeral;
-  bool? clearCache;
+  bool showFullscreen;
+  bool isMaterialStyle;
+  bool clearCache;
 
   CasdoorSdkParams copyWith({
     String? url,
@@ -57,7 +58,6 @@ class CasdoorSdkParams {
     BuildContext? buildContext,
     bool? showFullscreen,
     bool? isMaterialStyle,
-    bool? preferEphemeral,
     bool? clearCache,
   }) =>
       CasdoorSdkParams(
@@ -66,7 +66,6 @@ class CasdoorSdkParams {
         buildContext: buildContext ?? this.buildContext,
         showFullscreen: showFullscreen ?? this.showFullscreen,
         isMaterialStyle: isMaterialStyle ?? this.isMaterialStyle,
-        preferEphemeral: preferEphemeral ?? this.preferEphemeral,
         clearCache: clearCache ?? this.clearCache,
       );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.10.0
 homepage: https://github.com/casdoor/casdoor-flutter-sdk
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ flutter:
       macos:
         dartPluginClass: CasdoorFlutterSdkMobile
       windows:
-        dartPluginClass: CasdoorFlutterSdkMobile
+        dartPluginClass: CasdoorFlutterSdkDesktop
       web:
         pluginClass: CasdoorFlutterSdkWeb
         fileName: src/casdoor_flutter_sdk_web.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
 
-  path: ^1.9.1
+  path: ^1.9.0
   path_provider: ^2.1.5
   desktop_webview_window: ^0.2.3
   flutter_inappwebview: ^6.1.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,19 +14,19 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
 
-  path: ^1.8.2
-  path_provider: ^2.1.1
+  path: ^1.9.1
+  path_provider: ^2.1.5
   desktop_webview_window: ^0.2.3
-  flutter_inappwebview: ^6.0.0
-  http: ^1.0.0
-  crypto: ^3.0.2
+  flutter_inappwebview: ^6.1.5
+  http: ^1.4.0
+  crypto: ^3.0.6
   jwt_decoder: ^2.0.1
-  web: ^1.0.0
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -53,9 +53,9 @@ flutter:
       linux:
         dartPluginClass: CasdoorFlutterSdkDesktop
       macos:
-        dartPluginClass: CasdoorFlutterSdkDesktop
+        dartPluginClass: CasdoorFlutterSdkMobile
       windows:
-        dartPluginClass: CasdoorFlutterSdkDesktop
+        dartPluginClass: CasdoorFlutterSdkMobile
       web:
         pluginClass: CasdoorFlutterSdkWeb
         fileName: src/casdoor_flutter_sdk_web.dart


### PR DESCRIPTION
Fix: #51

This PR addresses issue #51 where the request for clearing the cache on logout is ignored. This happened because underlying browser implementations in the different platforms constantly change over time which requires active maintenance.

There are no breaking changes in this PR.